### PR TITLE
Add amneziawg-installer to Network tunnels

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 - [infranet](http://sourceforge.net/projects/infranet/) - Infranet is a system that attempts to circumvent web censorship by allowing clients to surreptitiously request sensitive content via cooperating Web servers distributed across the global Internet.
 - [fwlite](https://github.com/v3aqb/fwlite) - A powerful HTTP proxy server designed to circumvent the Great Firewall (GFW)
 - [code-talker-tunnel](https://crysp.uwaterloo.ca/software/CodeTalkerTunnel.html) - Code Talker Tunnel (previously called SkypeMorph) is a protocol camouflaging tool, designed to reshape traffic output of any censorship circumvention tool to look like Skype video calls
-- [stegotorus](https://sri-csl.github.io/stegotorus/) - StegoTorus, a tool that comprehensively disguises Tor from protocol analysis. To foil analysis of packet contents, Tor’s traffic is steganographed to resemble an innocuous cover protocol, such as HTTP.
+- [stegotorus](https://sri-csl.github.io/stegotorus/) - StegoTorus, a tool that comprehensively disguises Tor from protocol analysis. To foil analysis of packet contents, Tor's traffic is steganographed to resemble an innocuous cover protocol, such as HTTP.
 - [go-packetflagon](https://github.com/BrassHornCommunications/go-packetflagon/) - A local HTTP application that serves customised Proxy Auto Configuration files for your browser to help bypass Internet censorship.
 - [Firezone](https://www.firezone.dev/) - Self-hosted VPN server using WireGuard. Supports MFA, SSO, and has easy deployment options.
-- [amneziawg-installer](https://github.com/bivlked/amneziawg-installer) - Automated one-command setup of AmneziaWG 2.0 VPN on Ubuntu — an obfuscated WireGuard fork with DPI bypass, client management, and server hardening.
+- [amneziawg-installer](https://github.com/bivlked/amneziawg-installer) - Automated one-command setup of AmneziaWG 2.0 VPN on Ubuntu & Debian — an obfuscated WireGuard fork with DPI bypass, client management, and server hardening.
 
 ### Decentralized systems
 - [ipfs](https://github.com/ipfs/ipfs) - IPFS is a global, versioned, peer-to-peer filesystem ([awesome list](https://github.com/ipfs/awesome-ipfs))

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 - [stegotorus](https://sri-csl.github.io/stegotorus/) - StegoTorus, a tool that comprehensively disguises Tor from protocol analysis. To foil analysis of packet contents, Tor’s traffic is steganographed to resemble an innocuous cover protocol, such as HTTP.
 - [go-packetflagon](https://github.com/BrassHornCommunications/go-packetflagon/) - A local HTTP application that serves customised Proxy Auto Configuration files for your browser to help bypass Internet censorship.
 - [Firezone](https://www.firezone.dev/) - Self-hosted VPN server using WireGuard. Supports MFA, SSO, and has easy deployment options.
+- [amneziawg-installer](https://github.com/bivlked/amneziawg-installer) - Automated one-command setup of AmneziaWG 2.0 VPN on Ubuntu — an obfuscated WireGuard fork with DPI bypass, client management, and server hardening.
 
 ### Decentralized systems
 - [ipfs](https://github.com/ipfs/ipfs) - IPFS is a global, versioned, peer-to-peer filesystem ([awesome list](https://github.com/ipfs/awesome-ipfs))


### PR DESCRIPTION
## Description

Add [amneziawg-installer](https://github.com/bivlked/amneziawg-installer) to the **Network tunnels** section.

**amneziawg-installer** automates one-command deployment of [AmneziaWG 2.0](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module) VPN on Ubuntu & Debian servers. AmneziaWG is an obfuscated fork of WireGuard specifically designed to resist DPI-based censorship (used in Russia, Iran, China, Turkmenistan and other countries with internet restrictions).

### How it fights censorship:
- **DPI bypass:** AmneziaWG 2.0 uses junk packets, header obfuscation (H1-H4), padding (S1-S4), and CPS concealment (I1-I5) to make VPN traffic undetectable by Deep Packet Inspection systems
- **One-command setup:** Users can deploy a censorship-resistant VPN on a VPS without advanced Linux knowledge
- **Auto-hardening:** UFW firewall, Fail2Ban, sysctl tuning included by default
- **Client management:** Add/remove clients, generate QR codes, vpn:// URI for mobile import, backup/restore
- **Time-limited clients:** `--expires` flag with automatic cron-based expiry

### Project details:
- **Platforms:** Ubuntu 24.04/25.10, Debian 12/13
- **Language:** Bash
- **License:** MIT
- **Status:** Actively maintained
- **GitHub:** https://github.com/bivlked/amneziawg-installer