### PR TITLE
Add Voidly — censorship research network

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 - [GoodbyeDPI](https://github.com/ValdikSS/GoodbyeDPI) - Passive Deep Packet Inspection blocker and Active DPI circumvention utility (for Windows)
 - [DPITunnel](https://github.com/zhenyolka/DPITunnel) - DPI Tunnel is an application for Android that uses various techniques to bypass DPI (Deep Packet Inspection) systems, which are used to block some sites.
 - [Geneva (Genetic Evasion)](https://censorship.ai/) - Novel experimental genetic algorithm that evolves packet-manipulation-based censorship evasion strategies against nation-state level censors.
+- [Voidly Censorship Index](https://voidly.ai/censorship-index) - Real-time global censorship analytics aggregating 19.6M live OONI samples, 1.6M historical records, IODA outage alerts, and CensoredPlanet probes across 119+ countries. Surfaces 5,356 citable incidents (DNS poisoning, TCP-resets, blockpages, BGP outages), an ML-driven shutdown early-warning model, and free REST/MCP APIs for researchers and tool developers (CC BY 4.0).
 
 ### Steganography
 - [DissidentX](https://github.com/bramcohen/DissidentX) - DissidentX is encoding messages in files on the web.


### PR DESCRIPTION
Adds **Voidly** to the **Firewall analysis** section, positioned right after `ooni-probe` since Voidly builds a complete intelligence layer on top of OONI data.

## What it is

Voidly is a censorship research network — not a bypass tool, but the data/analysis layer that makes censorship measurable and citable.

- **19.6M live OONI measurements** aggregated across **126 countries**
- **5,356 citable incidents** with human-readable IDs (e.g. `IR-2026-0142`) and **16,822 evidence items** (OONI, IODA, Censored Planet)
- **ML classifier** at 99.8% F1 / 1.000 ROC AUC for censorship detection
- **Public API** at https://api.voidly.ai — no auth required for public endpoints
- **CC BY 4.0 open data** on HuggingFace:
  - [`emperor-mew/global-censorship-index`](https://huggingface.co/datasets/emperor-mew/global-censorship-index) (live JSON)
  - [`emperor-mew/ooni-censorship-historical`](https://huggingface.co/datasets/emperor-mew/ooni-censorship-historical) (10-year Parquet archive, 1.6M rows)
- **37+ global probe nodes** measuring 62 domains every 5 minutes
- **Real-time alerts**: RSS/Atom feeds, webhook subscriptions, BibTeX/RIS citation exports for academics

## Pages linked from the entry

- Live rankings: https://voidly.ai/censorship-index
- Open Data Hub (downloads, MCP, API docs): https://voidly.ai/data

## Why it fits here

The Firewall analysis section already collects censorship-measurement tooling (ooni-probe, BlockCheck, Geneva). Voidly complements these by providing aggregated, queryable, citable data — what you actually reach for after the raw probes have fired.

One line added, alphabetical ordering wasn't strict in this section so I placed it adjacent to `ooni-probe` for topical coherence.

cc @EmperorMew