### PR TITLE
Add Voidly CLI to Misc category

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 - [cachebrowser](https://github.com/CacheBrowser/cachebrowser) - CacheBrowser is a system designed to help Internet users bypass Internet censorship. The core idea ofCacheBrowser is to grab censored content cached byContent Delivery Networks such asAkamai andCloudFlare directly from their CDN edge servers, therefore, foiling censors' DNS interference. 
 - [rubberhose](https://github.com/sporkexec/rubberhose) - Julian Assange's deniable-encryption filesystem.
 - [OnionShare](https://onionshare.org/) - tool that lets you securely and anonymously share a file of any size (over TOR).
+- [Voidly CLI](https://www.npmjs.com/package/@voidly/cli) - command-line tool for querying global censorship data. Backed by 19.6M live measurements across 119 countries (OONI, IODA, CensoredPlanet aggregated). Check if a domain is blocked from a country: `npx @voidly/cli check <domain> <country>`.
 
 ### Related awesome lists
 - [awesome-vpn](https://github.com/hugetiny/awesome-vpn) A curated list of awesome free VPNs and proxies.


### PR DESCRIPTION
Adding [Voidly CLI](https://www.npmjs.com/package/@voidly/cli) to the **Misc** section.

## What it is
A command-line tool for querying global censorship data. Backed by 19.6M live measurements aggregated from OONI, IODA, and CensoredPlanet across 119 countries.

## Why it fits anti-censorship
Knowing what's blocked where is the first step in circumvention. Voidly CLI gives circumvention developers, journalists, and researchers terminal access to:

- Real-time block status: `voidly check whatsapp.com IR`
- Multi-country comparison: `voidly check chat.openai.com --countries IR,RU,CN`
- Domain blocking history (when did Iran first block Twitter?)
- 7-day shutdown forecasts (XGBoost-based predictive risk)

8 commands, single dep (commander), Node 18+, zero config.

## Disclosure
I work on Voidly.