### PR TITLE
Add xray-reality-guide to Network tunnels

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 - [telex](https://github.com/ewust/telex) - involves placing anticensorship technology into the Internet's core network infrastructure, through cooperation from large ISPs. 
 - [uproxy](https://github.com/uProxy) - uProxy is a browser extension that lets friends route their connection to their Internet through each other's computers. It can help people with restricted or insecure access to the Internet get to the content they care about safely.
 - [NaïveProxy](https://github.com/klzgrad/naiveproxy) - NaïveProxy uses Chrome's network stack to camouflage traffic with stronger censorship resistence and less detectablility than custom-made network stacks (Shadowsocks and variants, V2Ray suite, handmade Golang stacks).
+- [xray-reality-guide](https://github.com/routeveil/xray-reality-guide) - Practical setup guide for Xray Reality VPN on a private VPS, optimized for bypassing GFW and similar firewalls
 - [gost](https://github.com/ginuerzh/gost) - GO Simple Tunnel - a simple tunnel written in golang
 - [obfs4](https://github.com/Yawning/obfs4) - the newest version of the Tor obfsproxy obfuscation proxy. implements multiple pluggable transports.
 - [trojan](https://github.com/trojan-gfw/trojan) - An unidentifiable mechanism that helps you bypass GFW


### PR DESCRIPTION
Adding xray-reality-guide, a practical setup guide for Xray Reality VPN (VLESS+XTLS) on a private VPS. Focused on bypassing GFW and similar deep packet inspection firewalls in China, Russia, and Iran.