### PR TITLE
Add palazikVPN (Android Xray/V2Ray client)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 - [stegotorus](https://sri-csl.github.io/stegotorus/) - StegoTorus, a tool that comprehensively disguises Tor from protocol analysis. To foil analysis of packet contents, Tor’s traffic is steganographed to resemble an innocuous cover protocol, such as HTTP.
 - [go-packetflagon](https://github.com/BrassHornCommunications/go-packetflagon/) - A local HTTP application that serves customised Proxy Auto Configuration files for your browser to help bypass Internet censorship.
 - [Firezone](https://www.firezone.dev/) - Self-hosted VPN server using WireGuard. Supports MFA, SSO, and has easy deployment options.
+- [palazikVPN](https://github.com/palazik/palazikVPN) - Open-source Android client for Xray/V2Ray. Imports profiles and subscriptions and runs a full-device VPN; supports VLESS, VMess, Trojan, Shadowsocks, Hysteria2, TUIC, WireGuard and AnyTLS.
 
 ### Decentralized systems
 - [ipfs](https://github.com/ipfs/ipfs) - IPFS is a global, versioned, peer-to-peer filesystem ([awesome list](https://github.com/ipfs/awesome-ipfs))


### PR DESCRIPTION
Adds **palazikVPN** to the *Network tunnels* section.

It's a free, open-source Android client for Xray/V2Ray — imports profiles and subscriptions and runs a full-device VPN, supporting VLESS, VMess, Trojan, Shadowsocks, Hysteria2, TUIC, WireGuard and AnyTLS. No accounts, no telemetry.

Repo: https://github.com/palazik/palazikVPN

Single-line addition, following the existing entry format.