### PR TITLE
Add Stunning to Network tunnels

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 - [stegotorus](https://sri-csl.github.io/stegotorus/) - StegoTorus, a tool that comprehensively disguises Tor from protocol analysis. To foil analysis of packet contents, Tor’s traffic is steganographed to resemble an innocuous cover protocol, such as HTTP.
 - [go-packetflagon](https://github.com/BrassHornCommunications/go-packetflagon/) - A local HTTP application that serves customised Proxy Auto Configuration files for your browser to help bypass Internet censorship.
 - [Firezone](https://www.firezone.dev/) - Self-hosted VPN server using WireGuard. Supports MFA, SSO, and has easy deployment options.
+- [Stunning](https://github.com/hbahadorzadeh/stunning) - Multi-protocol tunneling engine with composable anti-DPI plugin chains (TLS/HTTP mimicry, padding, traffic morphing) and access-control gates, written in Go.
 
 ### Decentralized systems
 - [ipfs](https://github.com/ipfs/ipfs) - IPFS is a global, versioned, peer-to-peer filesystem ([awesome list](https://github.com/ipfs/awesome-ipfs))


### PR DESCRIPTION
Adds [Stunning](https://github.com/hbahadorzadeh/stunning) to the **Network tunnels** section.

Stunning is an open-source (GPLv3) multi-protocol tunneling engine written in Go. Its distinguishing feature is composable **anti-DPI plugin chains** — `tls-mimic`/`http-mimic` (disguise the wire as TLS/HTTP), padding, and traffic morphing — plus access-control gates (auth + single-packet port knocking). A high-entropy tunnel a censor would block passes cleanly once wrapped in `tls-mimic`, demonstrated end-to-end against a simulated DPI middlebox in the repo's test harness.

- Repo: https://github.com/hbahadorzadeh/stunning
- License: GPL-3.0
- One entry, added to the Network tunnels section.