### PR TITLE
Add Zapret Hub Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 
 ### Censorship bypass tools
 - [Zerodrop](https://dangerous.link/about) - Open-source stealth URL toolkit optimized for bypassing censorship filters.
+- [Zapret Hub Linux](https://github.com/DosAi/Zapret-Hub-Linux) - Kali Linux desktop interface for managing Zapret, Zapret2, Happ, and a local Telegram WebSocket proxy.
 
 ### Privacy and anonymity
 - [tor](https://www.torproject.org/about/overview.html.en) - The Tor network is a group of volunteer-operated servers that allows people to improve their privacy and security on the Internet. Tor's users employ this network by connecting through a series of virtual tunnels rather than making a direct connection


### PR DESCRIPTION
## What changed

- Added Zapret Hub Linux to the censorship bypass tools section.

## Why

Zapret Hub Linux is an MIT-licensed, Linux-only desktop control panel for Kali
Linux. It provides one interface for Zapret, Zapret2, Happ, and a local Telegram
WebSocket proxy. The project publishes an English README, screenshots, CI results,
and a checksum-verified release archive.

## Validation

- Confirmed the repository and latest release are public.
- Confirmed the entry points to the English-accessible project page.
- `git diff --check` passes.
