### PR TITLE
Add Hedioum Pool Tunnel to Network tunnels

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 - [stegotorus](https://sri-csl.github.io/stegotorus/) - StegoTorus, a tool that comprehensively disguises Tor from protocol analysis. To foil analysis of packet contents, Tor’s traffic is steganographed to resemble an innocuous cover protocol, such as HTTP.
 - [go-packetflagon](https://github.com/BrassHornCommunications/go-packetflagon/) - A local HTTP application that serves customised Proxy Auto Configuration files for your browser to help bypass Internet censorship.
 - [Firezone](https://www.firezone.dev/) - Self-hosted VPN server using WireGuard. Supports MFA, SSO, and has easy deployment options.
+- [Hedioum Pool Tunnel](https://github.com/hedioum/Hedioum-Pool-Tunnel) - A high-performance anti-DPI tunnel in Go that disguises VLESS/Trojan traffic as SSH, TLS/HTTPS, SMTP/IMAP or a DirectAdmin panel, with dynamic connection pools and real Let's Encrypt certificates.
 
 ### Decentralized systems
 - [ipfs](https://github.com/ipfs/ipfs) - IPFS is a global, versioned, peer-to-peer filesystem ([awesome list](https://github.com/ipfs/awesome-ipfs))


### PR DESCRIPTION
Adds [Hedioum Pool Tunnel](https://github.com/hedioum/Hedioum-Pool-Tunnel), an open-source (GPL-3.0) anti-DPI tunnel written in Go. It disguises VLESS/Trojan traffic as **SSH, TLS/HTTPS, STARTTLS SMTP/IMAP, implicit-TLS SMTPS/IMAPS, or a DirectAdmin panel**, over dynamically-scaling connection pools with per-install-varying on-wire signatures. It supports real auto-renewing Let's Encrypt certificates, full UDP-over-TCP (QUIC/HTTP3, DNS, calls), IPv6, and uTLS (Chrome ClientHello) to defeat JA3 fingerprinting.

Added under **### Network tunnels**, matching the existing entry format.