### PR TITLE
Add noctis under Network tunnels

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 - [stegotorus](https://sri-csl.github.io/stegotorus/) - StegoTorus, a tool that comprehensively disguises Tor from protocol analysis. To foil analysis of packet contents, Tor’s traffic is steganographed to resemble an innocuous cover protocol, such as HTTP.
 - [go-packetflagon](https://github.com/BrassHornCommunications/go-packetflagon/) - A local HTTP application that serves customised Proxy Auto Configuration files for your browser to help bypass Internet censorship.
 - [Firezone](https://www.firezone.dev/) - Self-hosted VPN server using WireGuard. Supports MFA, SSO, and has easy deployment options.
+- [noctis](https://noctis.c0nn3ct.info) - chrome extension that tunnels browser traffic through your own server over VLESS Reality, VMess, Trojan, Hysteria2 or TUIC, driven by a local sing-box, Xray or mihomo core
 
 ### Decentralized systems
 - [ipfs](https://github.com/ipfs/ipfs) - IPFS is a global, versioned, peer-to-peer filesystem ([awesome list](https://github.com/ipfs/awesome-ipfs))


### PR DESCRIPTION
Noctis puts the browser behind your own server without touching the rest of the system. A native helper runs a local sing-box, Xray or mihomo core, which covers the transports people reach for on filtered networks: VLESS Reality, VMess, Trojan, Shadowsocks, Hysteria2, TUIC and WireGuard. Per-host rules decide whether a request takes the proxy or goes direct.

Closest neighbours already on the list are uproxy and lantern, though both route differently.

- Site: https://noctis.c0nn3ct.info
- Web Store: https://chromewebstore.google.com/detail/noctis/nmhobajopepdpihahepaddpdifdcenpn
- Helper source, MIT: https://github.com/c0nn3ct-info/noctis

Added under Network tunnels, in the lower-case style the section uses.

Disclosure: I wrote Noctis.
