### PR TITLE
Add Caspian-BYOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 - [stegotorus](https://sri-csl.github.io/stegotorus/) - StegoTorus, a tool that comprehensively disguises Tor from protocol analysis. To foil analysis of packet contents, Tor’s traffic is steganographed to resemble an innocuous cover protocol, such as HTTP.
 - [go-packetflagon](https://github.com/BrassHornCommunications/go-packetflagon/) - A local HTTP application that serves customised Proxy Auto Configuration files for your browser to help bypass Internet censorship.
 - [Firezone](https://www.firezone.dev/) - Self-hosted VPN server using WireGuard. Supports MFA, SSO, and has easy deployment options.
+- [Caspian-BYOC](https://github.com/Iman/caspian) - Self-hosted WiFi gateway: a PC, Mac or Raspberry Pi shares an Xray tunnel (VLESS, REALITY, Trojan, Shadowsocks, Hysteria2) with every device on its hotspot, no client app needed.
 
 ### Decentralized systems
 - [ipfs](https://github.com/ipfs/ipfs) - IPFS is a global, versioned, peer-to-peer filesystem ([awesome list](https://github.com/ipfs/awesome-ipfs))


### PR DESCRIPTION
Adds Caspian-BYOC: https://github.com/Iman/caspian

Caspian-BYOC turns a Windows PC, a Mac, a Linux box or a Raspberry Pi into a WiFi hotspot. The user pastes one VLESS, VMess, Trojan, Shadowsocks, SOCKS or Hysteria2 share link (or Clash YAML, raw Xray JSON, or a base64 subscription) into a local web panel, and every device that joins the hotspot goes through the Xray tunnel with no client app installed on the phones. Fail-closed: if the tunnel drops, traffic is blocked rather than leaked.

Written in Go, AGPL-3.0-or-later, no telemetry, panel in English and Persian. Tagged releases with builds for Windows 10 version 2004 or later and Windows 11 (x64, arm64), macOS 13+ (Intel and Apple Silicon), Linux (x86_64, arm64, armv7, armv6) and Raspberry Pi.
