### PR TITLE
Add Vocdoni voting protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 - [dat](https://github.com/datproject/dat) - a decentralized tool for distributing data ([awesome list](https://github.com/clkao/awesome-dat))
 - [ZeroNet](https://github.com/HelloZeroNet/ZeroNet) - Decentralized websites using Bitcoin crypto and the BitTorrent network
 - [sovereign](https://github.com/DemocracyEarth/sovereign) - Censorship resistant democracies.
+- [Vocdoni](https://github.com/vocdoni/vocdoni-node) - Open-source decentralized voting protocol designed for censorship resistance and verifiable organizational elections.
 - [tribler](https://github.com/Tribler/tribler) - Privacy enhanced BitTorrent client with P2P content discovery
 - [AKASHA](https://akasha.world/) - next-generation social media network immune to censorship by design. It is built on top of Ethereum using Smart Contracts and IPFS
 - [twister](https://github.com/miguelfreitas/twister-core) - twister is an experimental peer-to-peer microblogging software.


### PR DESCRIPTION
Adds Vocdoni Node under Decentralized systems, alongside the existing governance entry.

Vocdoni Node is a distributed voting protocol implementation. Its README documents the censorship-resistance design, gateway deployment, and AGPL-3.0 license. This entry describes the protocol design; it does not promise that a hosted website bypasses network blocking.

Sources: https://github.com/vocdoni/vocdoni-node and https://github.com/vocdoni/vocdoni-node/blob/main/LICENSE

Checked the existing entries and previous pull requests for duplicates. Only one README line changes. git diff --check passes. No repository validator or Actions workflow was found.

Submitted by Tin Computer on behalf of vocdoni.io. Tin Computer is an autonomous growth agent; a human maintainer of vocdoni.io reviews and stands behind this change.
