### PR TITLE
Add Mandating Honeypots Project to Misc 

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 - [cachebrowser](https://github.com/CacheBrowser/cachebrowser) - CacheBrowser is a system designed to help Internet users bypass Internet censorship. The core idea ofCacheBrowser is to grab censored content cached byContent Delivery Networks such asAkamai andCloudFlare directly from their CDN edge servers, therefore, foiling censors' DNS interference. 
 - [rubberhose](https://github.com/sporkexec/rubberhose) - Julian Assange's deniable-encryption filesystem.
 - [OnionShare](https://onionshare.org/) - tool that lets you securely and anonymously share a file of any size (over TOR).
-- [The Mandating Honeypots Project](https://github.com/Tori-Tech/Mandating-Honeypots-Project) - An research project with a Python PoC that shows how Linux D-Bus age verification can be spoofed.
+- [The Mandating Honeypots Project](https://github.com/Tori-Tech/Mandating-Honeypots-Project) - A research project with a Python PoC that shows how Linux D-Bus age verification can be spoofed.
 
 ### Related awesome lists
 - [awesome-vpn](https://github.com/hugetiny/awesome-vpn) A curated list of awesome free VPNs and proxies.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 - [cachebrowser](https://github.com/CacheBrowser/cachebrowser) - CacheBrowser is a system designed to help Internet users bypass Internet censorship. The core idea ofCacheBrowser is to grab censored content cached byContent Delivery Networks such asAkamai andCloudFlare directly from their CDN edge servers, therefore, foiling censors' DNS interference. 
 - [rubberhose](https://github.com/sporkexec/rubberhose) - Julian Assange's deniable-encryption filesystem.
 - [OnionShare](https://onionshare.org/) - tool that lets you securely and anonymously share a file of any size (over TOR).
+- [The Mandating Honeypots Project](https://github.com/Tori-Tech/Mandating-Honeypots-Project) - An research project with a Python PoC that shows how Linux D-Bus age verification can be spoofed.
 
 ### Related awesome lists
 - [awesome-vpn](https://github.com/hugetiny/awesome-vpn) A curated list of awesome free VPNs and proxies.


### PR DESCRIPTION
I would like to submit The Mandating Honeypots Project to the Misc. section.

This is an open-source security research project with a Python PoC that demonstrates how client-side age verification through Linux D-Buses can be easily spoofed, and offers a localized, password-protected utility that could easily be expanded into a true, non-invasive alternative to ID verification.

Thank you for maintaining this list and reviewing my submission.