### PR TITLE
Add awg-config-gen to Network tunnels

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 - [Hedioum Pool Tunnel](https://github.com/hedioum/Hedioum-Pool-Tunnel) - A high-performance anti-DPI tunnel in Go that disguises VLESS/Trojan traffic as SSH, TLS/HTTPS, SMTP/IMAP or a DirectAdmin panel, with dynamic connection pools and real Let's Encrypt certificates.
 - [Stunning](https://github.com/hbahadorzadeh/stunning) - Multi-protocol tunneling engine with composable anti-DPI plugin chains (TLS/HTTP mimicry, padding, traffic morphing) and access-control gates, written in Go.
 - [amneziawg-installer](https://github.com/bivlked/amneziawg-installer) - Automated one-command setup of AmneziaWG 2.0 VPN on Ubuntu & Debian — an obfuscated WireGuard fork with DPI bypass, client management, and server hardening.
+- [awg-config-gen](https://github.com/Yuix-Networks/awg-config-gen) - Generates and audits AmneziaWG configs. Checks the obfuscation parameters against the upstream rules, including the ones AmneziaWG accepts silently: `S1 + 56 == S2` makes the handshake initiation and response the same size on the wire, and an `H` value of 1-4 leaves that message looking like plain WireGuard. The `check` command works on any existing config, not just ones it generated.
 
 ### Decentralized systems
 - [ipfs](https://github.com/ipfs/ipfs) - IPFS is a global, versioned, peer-to-peer filesystem ([awesome list](https://github.com/ipfs/awesome-ipfs))


### PR DESCRIPTION
Adds [awg-config-gen](https://github.com/Yuix-Networks/awg-config-gen), a generator and auditor for AmneziaWG configs.

Placed next to `amneziawg-installer` since both concern AmneziaWG, but they do different jobs: the installer stands a server up, this one produces and checks the configuration. Happy to move it to Misc if Network tunnels feels wrong — it is a tool about tunnels rather than a tunnel.

**Why it might be worth a line.** AmneziaWG's obfuscation parameters are documented, and getting one wrong produces no error. The tunnel comes up, traffic flows, `awg show` looks healthy, and the obfuscation is not doing what you think:

- `S1 + 56 == S2` makes the handshake initiation and response the same size on the wire — the exact fingerprint the padding was added to remove.
- An `H` value of 1-4 leaves that message type looking like plain WireGuard.
- `Jmax` at or above the system MTU fragments the junk packet, which is more conspicuous than sending none.

`awg-config-gen new` will not emit any of those, and `awg-config-gen check` finds them in configs it did not write — hand-written, copied from a forum, or produced by a panel that does not know the rules. It exits non-zero, so it fits in CI.

MIT, Python 3.8+, one dependency (`cryptography`, for X25519). Every rule is taken from the amneziawg-linux-kernel-module and amneziawg-go READMEs; the output spelling was checked against `awg-quick`. On PyPI as `awg-config-gen`.

Disclosure: I maintain it. We run AmneziaWG in production and wrote this because we kept finding these mistakes in our own configs.